### PR TITLE
Add floating money leaderboard data pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Money Leaderboard Data Pack
+
+This data pack adds a persistent, floating money leaderboard that updates automatically from a scoreboard-based currency system.
+
+## Currency storage
+
+* Player balances are stored in the `money` scoreboard objective as **cents** (e.g. `$12.34` is stored as `1234`).
+* Ranking values are mirrored to the `money_rank` objective for reference/debugging.
+
+### Useful scoreboard commands
+
+| Purpose | Command |
+| --- | --- |
+| Create the objective manually (if removed) | `/scoreboard objectives add money dummy "Money"` |
+| Give a player money | `/scoreboard players add <player> money <cents>` |
+| Set a player's balance | `/scoreboard players set <player> money <cents>` |
+| Remove money from a player | `/scoreboard players remove <player> money <cents>` |
+| Display your current balance | `/scoreboard players get <player> money` |
+
+Replace `<player>` with a name or selector (for example, `@p`). Remember to convert dollars to cents when entering amounts.
+
+## Leaderboard management functions
+
+| Action | Command |
+| --- | --- |
+| Create (or move) the floating leaderboard two blocks above you | `/function money:lb/create` |
+| Force an immediate leaderboard refresh | `/function money:admin/refresh` |
+| Destroy the floating leaderboard entity | `/function money:lb/destroy` |
+| Reset all balances and rankings | `/function money:admin/reset` |
+
+The leaderboard updates automatically every tick while a `money.leaderboard` text display entity exists.
+
+## Notes
+
+* The leaderboard lists up to the top ten players with the highest balances, formatting values as `$X.XX`.
+* Players with identical balances keep their order based on the first one found during the update pass.
+* You can relocate the leaderboard by destroying it and running `/function money:lb/create` at the new spot.

--- a/data/minecraft/tags/functions/load.json
+++ b/data/minecraft/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "money:load"
+  ]
+}

--- a/data/minecraft/tags/functions/tick.json
+++ b/data/minecraft/tags/functions/tick.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "money:tick"
+  ]
+}

--- a/data/money/functions/admin/refresh.mcfunction
+++ b/data/money/functions/admin/refresh.mcfunction
@@ -1,0 +1,1 @@
+function money:lb/update

--- a/data/money/functions/admin/reset.mcfunction
+++ b/data/money/functions/admin/reset.mcfunction
@@ -1,0 +1,5 @@
+scoreboard players reset @a money
+scoreboard players reset @a money_rank
+tag @a remove money.lb_selected
+tag @a remove money.max_candidate
+function money:lb/update

--- a/data/money/functions/lb/apply_text.mcfunction
+++ b/data/money/functions/lb/apply_text.mcfunction
@@ -1,0 +1,3 @@
+data modify storage money:board text set value {"text":"Money Leaderboard","color":"gold","bold":true,"extra":[]}
+function money:lb/apply_text_lines
+execute as @e[type=minecraft:text_display,tag=money.leaderboard] run data modify entity @s text set from storage money:board text

--- a/data/money/functions/lb/apply_text_lines.mcfunction
+++ b/data/money/functions/lb/apply_text_lines.mcfunction
@@ -1,0 +1,1 @@
+execute if data storage money:board lines[0] run function money:lb/apply_text_next

--- a/data/money/functions/lb/apply_text_next.mcfunction
+++ b/data/money/functions/lb/apply_text_next.mcfunction
@@ -1,0 +1,4 @@
+data modify storage money:board text.extra append value {"text":"\n"}
+data modify storage money:board text.extra append from storage money:board lines[0]
+data remove storage money:board lines[0]
+function money:lb/apply_text_lines

--- a/data/money/functions/lb/assign_rank.mcfunction
+++ b/data/money/functions/lb/assign_rank.mcfunction
@@ -1,0 +1,4 @@
+scoreboard players operation @s money_rank = #rank money_helper
+tag @s add money.lb_selected
+function money:lb/build_line
+tag @a remove money.max_candidate

--- a/data/money/functions/lb/build_line.mcfunction
+++ b/data/money/functions/lb/build_line.mcfunction
@@ -1,0 +1,20 @@
+scoreboard players operation #dollars money_helper = @s money
+scoreboard players operation #dollars money_helper /= #hundred money_helper
+scoreboard players operation #cents money_helper = @s money
+scoreboard players operation #cents money_helper %= #hundred money_helper
+data modify storage money:board temp set value {}
+execute store result storage money:board temp.rank int 1 run scoreboard players get @s money_rank
+execute store result storage money:board temp.dollars int 1 run scoreboard players get #dollars money_helper
+execute store result storage money:board temp.cents int 1 run scoreboard players get #cents money_helper
+data modify storage money:board temp.line set value {"text":"","extra":[]}
+data modify storage money:board temp.line.extra append value {"nbt":"temp.rank","storage":"money:board","color":"gold","bold":true}
+data modify storage money:board temp.line.extra append value {"text":". ","color":"gold"}
+data modify storage money:board temp.line.extra append value {"selector":"@s","color":"white"}
+data modify storage money:board temp.line.extra append value {"text":" - $","color":"yellow"}
+data modify storage money:board temp.line.extra append value {"nbt":"temp.dollars","storage":"money:board","color":"yellow"}
+data modify storage money:board temp.line.extra append value {"text":".","color":"yellow"}
+execute if score #cents money_helper < #ten money_helper run data modify storage money:board temp.line.extra append value {"text":"0","color":"yellow"}
+data modify storage money:board temp.line.extra append value {"nbt":"temp.cents","storage":"money:board","color":"yellow"}
+data modify storage money:board temp.line.extra append value {"text":"$","color":"yellow"}
+data modify storage money:board lines append from storage money:board temp.line
+data remove storage money:board temp

--- a/data/money/functions/lb/compare.mcfunction
+++ b/data/money/functions/lb/compare.mcfunction
@@ -1,0 +1,1 @@
+execute if entity @s[tag=!money.lb_selected] run function money:lb/compare_active

--- a/data/money/functions/lb/compare_active.mcfunction
+++ b/data/money/functions/lb/compare_active.mcfunction
@@ -1,0 +1,2 @@
+execute if score @s money > #max money_helper run function money:lb/new_max
+execute if score @s money = #max money_helper run tag @s add money.max_candidate

--- a/data/money/functions/lb/create.mcfunction
+++ b/data/money/functions/lb/create.mcfunction
@@ -1,0 +1,3 @@
+execute unless entity @e[type=minecraft:text_display,tag=money.leaderboard,limit=1] run summon minecraft:text_display ~ ~2 ~ {Tags:["money.leaderboard"],billboard:"vertical",alignment:"left",background:0,shadow:1b,line_width:200}
+execute as @e[type=minecraft:text_display,tag=money.leaderboard,limit=1] run data merge entity @s {billboard:"vertical",alignment:"left",background:0,shadow:1b,line_width:200}
+function money:lb/update

--- a/data/money/functions/lb/destroy.mcfunction
+++ b/data/money/functions/lb/destroy.mcfunction
@@ -1,0 +1,1 @@
+kill @e[type=minecraft:text_display,tag=money.leaderboard]

--- a/data/money/functions/lb/new_max.mcfunction
+++ b/data/money/functions/lb/new_max.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players operation #max money_helper = @s money
+tag @a remove money.max_candidate
+tag @s add money.max_candidate

--- a/data/money/functions/lb/rank_loop.mcfunction
+++ b/data/money/functions/lb/rank_loop.mcfunction
@@ -1,0 +1,9 @@
+execute unless entity @a[tag=!money.lb_selected] run return 1
+scoreboard players add #rank money_helper 1
+execute if score #rank money_helper > #limit money_helper run return 1
+scoreboard players set #max money_helper -2000000000
+tag @a remove money.max_candidate
+execute as @a[tag=!money.lb_selected] run function money:lb/compare
+execute if score #max money_helper matches -2000000000 run return 1
+execute as @a[tag=money.max_candidate,limit=1,sort=arbitrary] run function money:lb/assign_rank
+function money:lb/rank_loop

--- a/data/money/functions/lb/update.mcfunction
+++ b/data/money/functions/lb/update.mcfunction
@@ -1,0 +1,6 @@
+scoreboard players reset @a money_rank
+scoreboard players set #rank money_helper 0
+tag @a remove money.lb_selected
+data modify storage money:board lines set value []
+function money:lb/rank_loop
+function money:lb/apply_text

--- a/data/money/functions/load.mcfunction
+++ b/data/money/functions/load.mcfunction
@@ -1,0 +1,15 @@
+scoreboard objectives add money_helper dummy
+scoreboard objectives add money dummy {"text":"Money","color":"yellow"}
+scoreboard objectives add money_rank dummy {"text":"Money Rank","color":"gold"}
+scoreboard players set #hundred money_helper 100
+scoreboard players set #ten money_helper 10
+scoreboard players set #limit money_helper 10
+scoreboard players set #min money_helper -2000000000
+scoreboard players set #rank money_helper 0
+scoreboard players set #max money_helper 0
+scoreboard players set #dollars money_helper 0
+scoreboard players set #cents money_helper 0
+data modify storage money:board lines set value []
+data modify storage money:board text set value {"text":"Money Leaderboard","color":"gold","bold":true}
+tag @a remove money.lb_selected
+tag @a remove money.max_candidate

--- a/data/money/functions/tick.mcfunction
+++ b/data/money/functions/tick.mcfunction
@@ -1,0 +1,1 @@
+execute if entity @e[type=minecraft:text_display,tag=money.leaderboard] run function money:lb/update

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,7 +1,7 @@
 {
-	"pack": {
-		"min_format": 88,
-	    "max_format": 88,
-		"description": "Leaderboards from scoreboards v4.0"
-	}
+  "pack": {
+    "min_format": 88,
+    "max_format": 88,
+    "description": "Leaderboards from scoreboards v4.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add scoreboard-backed currency storage and helper setup logic for the money leaderboard
- implement functions to create, refresh, and destroy an auto-updating floating text leaderboard
- document the required scoreboard and function commands for administering the system

## Testing
- not run (data pack content)


------
https://chatgpt.com/codex/tasks/task_e_68e1fe8fdd8c83239773923dd5ce2a44