### PR TITLE
Update pack metadata for Minecraft 1.21.9

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,7 +1,6 @@
 {
-  "pack": {
-    "min_format": 88,
-    "max_format": 88,
-    "description": "Leaderboards from scoreboards v4.0"
-  }
+    "pack": {
+      "pack_format": 58,
+      "description": "Leaderboards from scoreboards v4.0"
+    }
 }


### PR DESCRIPTION
## Summary
- bump the datapack metadata to pack_format 58 to meet Minecraft 1.21.9 requirements

## Testing
- not run (Minecraft client/server not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2094e04008323be6c16c216406b7d